### PR TITLE
Here, someone has manually edited the client

### DIFF
--- a/client/sdk.gen.ts
+++ b/client/sdk.gen.ts
@@ -65,3 +65,17 @@ export const updateTodo = <ThrowOnError extends boolean = false>(options: Option
         }
     });
 };
+
+/**
+ * Update a specific todo by ID
+ */
+export const deleteTodo = <ThrowOnError extends boolean = false>(options: Options<UpdateTodoData, ThrowOnError>) => {
+    return (options.client ?? _heyApiClient).delete<UpdateTodoResponse, unknown, ThrowOnError>({
+        url: '/todos/{todoId}',
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options?.headers
+        }
+    });
+};


### PR DESCRIPTION
The way that we guard agains this is we basically generate a client from our OpenAPI specification, and if there is any different between that and the content of the client folder, we raise a flag. 

Thus, from this we can be confident that the client is a completely faithful representation of the OpenAPI specification, with nothing omitted or added. 