### PR TITLE
This breaks due to statically detected breaking changes! 

### DIFF
--- a/client/types.gen.ts
+++ b/client/types.gen.ts
@@ -3,7 +3,6 @@
 export type Todo = {
     id: number;
     title: string;
-    completed: boolean;
 };
 
 export type NewTodo = {

--- a/server/server.py
+++ b/server/server.py
@@ -7,8 +7,8 @@ and updating existing todos. The API conforms to an OpenAPI 3.0.3 specification
 with custom extensions like `x-operationname` to assist in client code generation.
 
 Endpoints:
-  GET    /todos           - Retrieve a list of todos
-  POST   /todos           - Create a new todo
+  GET    /todos             - Retrieve a list of todos
+  POST   /todos             - Create a new todo
   GET    /todos/<todoId>    - Retrieve a specific todo
   PUT    /todos/<todoId>    - Update a specific todo
 """
@@ -42,8 +42,7 @@ def add_todo():
 
     Request JSON Body:
     {
-        "title": "string",          # Required
-        "completed": false          # Optional, defaults to false
+        "title": "string"   # Required
     }
 
     Returns:
@@ -56,11 +55,9 @@ def add_todo():
     if not data or 'title' not in data:
         abort(400, description="Missing required field 'title'")
     
-    # Create a new todo item; if 'completed' is not provided, default to False.
     todo = {
         'id': next_id,
-        'title': data['title'],
-        'completed': data.get('completed', False)
+        'title': data['title']
     }
     todos.append(todo)
     next_id += 1
@@ -71,9 +68,6 @@ def fetch_todo(todoId):
     """
     GET /todos/<todoId>
     Retrieve a specific todo item by ID.
-
-    Path Parameters:
-        todoId (int): ID of the todo to retrieve.
 
     Returns:
         200 OK with the todo object if found.
@@ -92,13 +86,9 @@ def modify_todo(todoId):
     PUT /todos/<todoId>
     Update an existing todo item by ID.
 
-    Path Parameters:
-        todoId (int): ID of the todo to update.
-
     Request JSON Body:
     {
-        "title": "string",          # Required
-        "completed": true|false     # Required
+        "title": "string"   # Required
     }
 
     Returns:
@@ -109,16 +99,14 @@ def modify_todo(todoId):
     x-operationname: modifyTodo
     """
     data = request.get_json()
-    if not data or 'title' not in data or 'completed' not in data:
-        abort(400, description="Missing required fields 'title' and/or 'completed'")
+    if not data or 'title' not in data:
+        abort(400, description="Missing required field 'title'")
     
     todo = next((item for item in todos if item['id'] == todoId), None)
     if todo is None:
         abort(404, description="Todo not found")
     
-    # Update the todo item
     todo['title'] = data['title']
-    todo['completed'] = data['completed']
     return jsonify(todo), 200
 
 if __name__ == '__main__':

--- a/spec/server.yaml
+++ b/spec/server.yaml
@@ -94,13 +94,11 @@ components:
         title:
           type: string
           example: "Buy groceries"
-        completed:
-          type: boolean
-          example: false
+        # 🚨 BREAKING: Removed 'completed' field
       required:
         - id
         - title
-        - completed
+        # 🚨 BREAKING: 'completed' also removed from required
     NewTodo:
       type: object
       properties:

--- a/tests/integration/client.gen.test.ts
+++ b/tests/integration/client.gen.test.ts
@@ -31,7 +31,6 @@ describe("Todo API Integration Tests", () => {
     expect(todo).toHaveProperty("id");
     expect(todo?.title).toBe(testTitle);
     // The API should default "completed" to false when omitted.
-    expect(todo?.completed).toBe(false);
     createdTodoId = todo?.id;
   });
 
@@ -99,7 +98,6 @@ describe("Todo API Integration Tests", () => {
     expect(todo).toBeDefined();
     expect(todo?.id).toBe(createdTodoId);
     expect(todo?.title).toBe(updatedTitle);
-    expect(todo?.completed).toBe(true);
   });
 
   // PUT /todos/{todoId}: Update an existing todo with missing required fields; expect a 400.
@@ -112,7 +110,7 @@ describe("Todo API Integration Tests", () => {
       await updateTodo({
         path: { todoId: createdTodoId },
         // Body is missing 'completed'
-        body: { id: createdTodoId, title: "Incomplete Update" } as any,
+        body: { id: createdTodoId } as any,
         throwOnError: true,
       });
       fail("Expected a 400 error for missing required fields");
@@ -133,7 +131,7 @@ describe("Todo API Integration Tests", () => {
     try {
       await updateTodo({
         path: { todoId: -1 },
-        body: { id: -1, title: "Non-existent", completed: false },
+        body: { id: -1, title: "Non-existent"},
         throwOnError: true,
       });
       fail("Expected a 404 error for a non-existent todo");


### PR DESCRIPTION
Here, I have removed the completed field from the TODO item, a reductive breaking changes. 

Using OASDiff, however, my CI has caught that this is a breaking change based purely on my OpenAPI specification even though I have updated my 

- Client
- Tests
- The server itself 

Since I have not incremented by OpenAPI specification version by a major bump, it will not let me merge : - ) 

