### PR TITLE
This breaks due to version discrepancy between client, server and spec. Consequently ensures same version = client and server work together

### DIFF
--- a/spec/server.yaml
+++ b/spec/server.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: Todo API
-  version: "1.0.0"
+  version: "1.5.0"
   description: |
     A simple Todo API that demonstrates endpoints for managing todos.
     This spec includes custom extensions like `x-operationname` to guide client generation.


### PR DESCRIPTION
Essentially, this ensures that when the client and server are published, they are always compatible with each other. So when you use a server with version 1.0.1, you can be damn sure it was tested wth client version 1.0.1. 

This is because it is impossible to commit to main, which triggers the package publishing unless
1) You passed integration testing
2) Your server/client/openAPI versions were in sync 